### PR TITLE
Update travis build with latest and greatest

### DIFF
--- a/.build_scripts/deploy.sh
+++ b/.build_scripts/deploy.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
-# If this is the publish branch, push it up to gh-pages
-if [ $TRAVIS_PULL_REQUEST = "false" ] && [ $TRAVIS_BRANCH = "publish" ]; then
-  echo "Get ready, we're publishing!"
-  cd _site
-  git init
-  git config user.name "DevSeed Build Bot"
-  git config user.email "dsbb@developmentseed.org"
-  git add .
-  git commit -m "CI deploy to gh-pages"
-  git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:master
-else
-  echo "Not a publishable branch so we're all done here"
-fi
+echo "Get ready, we're pushing to gh-pages!"
+cd _site
+cp ../CNAME ./
+git init
+git config user.name "DevSeed Build Bot"
+git config user.email "dsbb@developmentseed.org"
+git add .
+git commit -m "CI deploy to gh-pages"
+git push --force --quiet "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" master:gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ node_js:
 
 env:
   global:
-  - GH_REF=github.com/climatescope/climatescope.github.io.git
-  - DEPLOY_BRANCH=publish
-  - secure: "Z159wfAlqF9wjKIQidjYCECUMQb3SvB5IvpaKKsXXx0ghd6KAfH/74BGrgOHcPWu67mqKOSGdqQDe2RZ3A3WA8f1aPwT+1Qw6OeaIxWD8eMTL58gEhY68PlhnTUvY+QwV7ufxxi/gZGltvM/1+X3nA12hzyfV/Tn+gqrpEMEUmM="
+  - DEPLOY_BRANCH=master
+  - secure: "uYdQRkIMLm9zOnOhCLnczYEhmj9vAdomAbh8/qIDxFLQ5l0fBTlpKTggsxUIZ06MPEFyAlQ7TVpLsPEPy9VwyIi9AE4PHTgo5iHFb1tiU92wmJew470lH8t92mGAP2CebcPf6cCqLBC8+i8uRl1w8USZGeqW+RJtlMwHlK9xBMo="
 
 before_install:
 - chmod +x ./.build_scripts/deploy.sh
@@ -14,5 +13,9 @@ before_install:
 script:
 - gulp prod
 
-after_success:
-- ./.build_scripts/deploy.sh
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: .build_scripts/deploy.sh
+  on:
+    branch: ${DEPLOY_BRANCH}


### PR DESCRIPTION
This PR should allow us to a more standard master/develop setup.
After pulling this and #34 in, we should:

1. [x] create a `gh-pages` branch from `master`. This will become the branch with the built site
2. [x] remove `master` and make sure site still runs well
2. [ ] create a new branch `develop` from `publish`
3. [ ] create a new branch `master` from `develop`
4. [ ] remove `publish`
5. [ ] set `develop` as default branch
6. [ ] protect the `master` branch