### PR TITLE
No need to copy CNAME

### DIFF
--- a/.build_scripts/deploy.sh
+++ b/.build_scripts/deploy.sh
@@ -3,7 +3,6 @@ set -e # halt script on error
 
 echo "Get ready, we're pushing to gh-pages!"
 cd _site
-cp ../CNAME ./
 git init
 git config user.name "DevSeed Build Bot"
 git config user.email "dsbb@developmentseed.org"


### PR DESCRIPTION
The build process is tripping on this. The CNAME is already part of the _site and not in the root of the project