### PR TITLE
SEO: Fix canonical url

### DIFF
--- a/src/components/SEO/index.js
+++ b/src/components/SEO/index.js
@@ -14,7 +14,7 @@ const SEO = ({
 }) => {
   const { basePath, asPath } = useRouter()
 
-  const slugUrl = siteUrl + basePath + asPath
+  const slugUrl = siteUrl + basePath + (asPath[0] === "/" ? asPath.slice(1) : asPath)
   const coverImg = cover ? siteUrl + basePath + "images/" + cover : ""
 
   const combinedTitle = title


### PR DESCRIPTION
Current logic caused the URL to be `<link rel="canonical" href="https://www.global-climatescope.org//results/">`, notice the double `/`.

Copied correct logic from https://github.com/climatescope/climatescope.org/blob/0ca0788391461c6626d950afdfbf3ee01afa2bdc/src/components/ShareButton/index.js#L40-L41